### PR TITLE
Add more info for translation responses

### DIFF
--- a/CommandProcessor.py
+++ b/CommandProcessor.py
@@ -1,9 +1,9 @@
-from TranslatorModule import TranslatorModule
+from TranslationModule import TranslationModule
 
 class CommandProcessor:
     @classmethod
     async def create(cls, config):
-        translator = await TranslatorModule.create(config)
+        translator = await TranslationModule.create(config)
 
         return cls(translator)
     

--- a/CommandResponse.py
+++ b/CommandResponse.py
@@ -1,0 +1,12 @@
+import enum
+import string
+
+class CommandResponseType(enum.Enum):
+    MESSAGE = 1
+
+class CommandResponse:
+    type: CommandResponseType
+    status: string
+    command_type: string
+    error: string
+    content: object

--- a/DuckBot.py
+++ b/DuckBot.py
@@ -3,6 +3,7 @@ import psycopg2
 from MatrixClient import MatrixClient
 from MatrixClientPgStorage import MatrixClientPgStorage
 from CommandProcessor import CommandProcessor
+from CommandResponse import CommandResponseType
 
 class DuckBot:
     @classmethod
@@ -41,8 +42,9 @@ class DuckBot:
         if not cmd_result:
             return
 
-        if cmd_result["type"] == "translation":
-            if cmd_result["status"] == "success":
-                await self.matrix_client.send_room_message(room_info["room_id"], cmd_result["text"])
-            elif cmd_result["status"] == "error":
-                await self.matrix_client.send_room_message(room_info["room_id"], json.dumps(cmd_result["error"]))
+        await self.process_command_response(cmd_result, room_info)
+    
+    async def process_command_response(self, cmd_result, room_info):
+        match cmd_result.type:
+            case CommandResponseType.MESSAGE:
+                await self.matrix_client.send_room_message(room_info["room_id"], cmd_result.content)


### PR DESCRIPTION
- Create CommandResponse and CommandResponseType to standardize responses.
- Rename TranslatorModule -> TranslationModule.
- Change response from TranslationModule to use new CommandResponse.
- Handle responses more generally in DuckBot to simplify development.

Closes #17 